### PR TITLE
added support for F13 to F24

### DIFF
--- a/src/Keyboard.cpp
+++ b/src/Keyboard.cpp
@@ -51,11 +51,11 @@ static const uint8_t _hidReportDescriptor[] PROGMEM = {
   0x95, 0x06,                    //   REPORT_COUNT (6)
     0x75, 0x08,                    //   REPORT_SIZE (8)
     0x15, 0x00,                    //   LOGICAL_MINIMUM (0)
-    0x25, 0x65,                    //   LOGICAL_MAXIMUM (101)
+    0x25, 0x73,                    //   LOGICAL_MAXIMUM (115)
     0x05, 0x07,                    //   USAGE_PAGE (Keyboard)
     
   0x19, 0x00,                    //   USAGE_MINIMUM (Reserved (no event indicated))
-    0x29, 0x65,                    //   USAGE_MAXIMUM (Keyboard Application)
+    0x29, 0x73,                    //   USAGE_MAXIMUM (Keyboard Application)
     0x81, 0x00,                    //   INPUT (Data,Ary,Abs)
     0xc0,                          // END_COLLECTION
 };
@@ -320,3 +320,4 @@ size_t Keyboard_::write(uint8_t c)
 Keyboard_ Keyboard;
 
 #endif
+

--- a/src/Keyboard.h
+++ b/src/Keyboard.h
@@ -70,6 +70,19 @@
 #define KEY_F10       0xCB
 #define KEY_F11       0xCC
 #define KEY_F12       0xCD
+#define KEY_F13       0xF0
+#define KEY_F14       0xF1
+#define KEY_F15       0xF2
+#define KEY_F16       0xF3
+#define KEY_F17       0xF4
+#define KEY_F18       0xF5
+#define KEY_F19       0xF6
+#define KEY_F20       0xF7
+#define KEY_F21       0xF8
+#define KEY_F22       0xF9
+#define KEY_F23       0xFA
+#define KEY_F24       0xFB
+
 
 //  Low level key report: up to 6 keys and shift, ctrl etc at once
 typedef struct
@@ -97,3 +110,4 @@ extern Keyboard_ Keyboard;
 
 #endif
 #endif
+


### PR DESCRIPTION
Added support for F13 to F24 keys by altering the report descriptor. Also added convenience definitions in the header following existing format.