### PR TITLE
Remove incorrect statement re: HID.h from readme

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,7 +1,6 @@
 = Keyboard Library for Arduino =
 
 This library allows an Arduino board with USB capabilities to act as a Keyboard.
-Being based on HID library you need to include "HID.h" in your sketch.
 
 For more information about this library please visit us at
 https://www.arduino.cc/reference/en/language/functions/usb/keyboard/


### PR DESCRIPTION
It has not been necessary to include dependencies of libraries in the sketch since Arduino IDE 1.6.5 and that (and previous) IDE version did not contain the Mouse or HID libraries since their functions were part of the core so I don't think there is any need for this sentence in the readme.

Reference: https://github.com/arduino-libraries/Mouse/pull/5