### PR TITLE
Fix broken link to library URL

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -5,5 +5,5 @@ maintainer=Arduino <info@arduino.cc>
 sentence=Allows an Arduino/Genuino board with USB capabilites to act as a Keyboard.
 paragraph=This library plugs on the HID library. It can be used with or without other HID-based libraries (Mouse, Gamepad etc)
 category=Device Control
-url=http://www.arduino.cc/en/Reference/Keyboard
+url=https://www.arduino.cc/reference/en/language/functions/usb/keyboard/
 architectures=*


### PR DESCRIPTION
The [old link to the library](https://www.arduino.cc/en/Reference/Keyboard) is broken
which results in its users not being able to access the necessary documentation.