### PR TITLE
Add Keyboard Serial example from arduino.cc

### DIFF
--- a/examples/Serial/Serial.ino
+++ b/examples/Serial/Serial.ino
@@ -1,0 +1,39 @@
+/*
+  Keyboard test
+
+  For the Arduino Leonardo, Micro or Due
+
+  Reads a byte from the serial port, sends a keystroke back.
+  The sent keystroke is one higher than what's received, e.g. if you send a,
+  you get b, send A you get B, and so forth.
+
+  The circuit:
+  - none
+
+  created 21 Oct 2011
+  modified 27 Mar 2012
+  by Tom Igoe
+
+  This example code is in the public domain.
+
+  http://www.arduino.cc/en/Tutorial/KeyboardSerial
+*/
+
+#include "Keyboard.h"
+
+void setup() {
+  // open the serial port:
+  Serial.begin(9600);
+  // initialize control over the keyboard:
+  Keyboard.begin();
+}
+
+void loop() {
+  // check for incoming serial data:
+  if (Serial.available() > 0) {
+    // read incoming serial data:
+    char inChar = Serial.read();
+    // Type the next ASCII value from what you received:
+    Keyboard.write(inChar + 1);
+  }
+}


### PR DESCRIPTION
Hi there,

I'm currently really interested in working on [this](https://github.com/arduino/summer-of-code/blob/master/ideas.md#idea-write-examples-for-official-libraries).

I was hoping to go ahead and take a look at whether I could add a simple example to a library like (Keyboard)[https://github.com/arduino-libraries/Keyboard].  In doing so, I noticed quite a number of examples on the [website](https://www.arduino.cc/en/Tutorial/KeyboardSerial) that don't exist here.

Hence, I submitted a PR just to add a copy (not my code) of one of the code examples into the official library.  If this is something that would be helpful, I can do the simple work of doing this for the rest of the examples.

Thanks!  Would love your thoughts!