### PR TITLE
Add additional examples as seen on arduino.cc

### DIFF
--- a/examples/Logout/Logout.ino
+++ b/examples/Logout/Logout.ino
@@ -1,0 +1,89 @@
+/*
+  Keyboard logout
+
+  This sketch demonstrates the Keyboard library.
+
+  When you connect pin 2 to ground, it performs a logout.
+  It uses keyboard combinations to do this, as follows:
+
+  On Windows, CTRL-ALT-DEL followed by ALT-l
+  On Ubuntu, CTRL-ALT-DEL, and ENTER
+  On OSX, CMD-SHIFT-q
+
+  To wake: Spacebar.
+
+  Circuit:
+  - Arduino Leonardo or Micro
+  - wire to connect D2 to ground
+
+  created 6 Mar 2012
+  modified 27 Mar 2012
+  by Tom Igoe
+
+  This example is in the public domain.
+
+  http://www.arduino.cc/en/Tutorial/KeyboardLogout
+*/
+
+#define OSX 0
+#define WINDOWS 1
+#define UBUNTU 2
+
+#include "Keyboard.h"
+
+// change this to match your platform:
+int platform = OSX;
+
+void setup() {
+  // make pin 2 an input and turn on the pull-up resistor so it goes high unless
+  // connected to ground:
+  pinMode(2, INPUT_PULLUP);
+  Keyboard.begin();
+}
+
+void loop() {
+  while (digitalRead(2) == HIGH) {
+    // do nothing until pin 2 goes low
+    delay(500);
+  }
+  delay(1000);
+
+  switch (platform) {
+    case OSX:
+      Keyboard.press(KEY_LEFT_GUI);
+      // Shift-Q logs out:
+      Keyboard.press(KEY_LEFT_SHIFT);
+      Keyboard.press('Q');
+      delay(100);
+      Keyboard.releaseAll();
+      // enter:
+      Keyboard.write(KEY_RETURN);
+      break;
+    case WINDOWS:
+      // CTRL-ALT-DEL:
+      Keyboard.press(KEY_LEFT_CTRL);
+      Keyboard.press(KEY_LEFT_ALT);
+      Keyboard.press(KEY_DELETE);
+      delay(100);
+      Keyboard.releaseAll();
+      // ALT-l:
+      delay(2000);
+      Keyboard.press(KEY_LEFT_ALT);
+      Keyboard.press('l');
+      Keyboard.releaseAll();
+      break;
+    case UBUNTU:
+      // CTRL-ALT-DEL:
+      Keyboard.press(KEY_LEFT_CTRL);
+      Keyboard.press(KEY_LEFT_ALT);
+      Keyboard.press(KEY_DELETE);
+      delay(1000);
+      Keyboard.releaseAll();
+      // Enter to confirm logout:
+      Keyboard.write(KEY_RETURN);
+      break;
+  }
+
+  // do nothing:
+  while (true);
+}

--- a/examples/Message/Message.ino
+++ b/examples/Message/Message.ino
@@ -1,0 +1,52 @@
+/*
+  Keyboard Message test
+
+  For the Arduino Leonardo and Micro.
+
+  Sends a text string when a button is pressed.
+
+  The circuit:
+  - pushbutton attached from pin 4 to +5V
+  - 10 kilohm resistor attached from pin 4 to ground
+
+  created 24 Oct 2011
+  modified 27 Mar 2012
+  by Tom Igoe
+  modified 11 Nov 2013
+  by Scott Fitzgerald
+
+  This example code is in the public domain.
+
+  http://www.arduino.cc/en/Tutorial/KeyboardMessage
+*/
+
+#include "Keyboard.h"
+
+const int buttonPin = 4;          // input pin for pushbutton
+int previousButtonState = HIGH;   // for checking the state of a pushButton
+int counter = 0;                  // button push counter
+
+void setup() {
+  // make the pushButton pin an input:
+  pinMode(buttonPin, INPUT);
+  // initialize control over the keyboard:
+  Keyboard.begin();
+}
+
+void loop() {
+  // read the pushbutton:
+  int buttonState = digitalRead(buttonPin);
+  // if the button state has changed,
+  if ((buttonState != previousButtonState)
+      // and it's currently pressed:
+      && (buttonState == HIGH)) {
+    // increment the button counter
+    counter++;
+    // type out a message
+    Keyboard.print("You pressed the button ");
+    Keyboard.print(counter);
+    Keyboard.println(" times.");
+  }
+  // save the current button state for comparison next time:
+  previousButtonState = buttonState;
+}

--- a/examples/Reprogram/Reprogram.ino
+++ b/examples/Reprogram/Reprogram.ino
@@ -1,0 +1,103 @@
+/*
+  Arduino Programs Blink
+
+  This sketch demonstrates the Keyboard library.
+
+  For Leonardo and Due boards only.
+
+  When you connect pin 2 to ground, it creates a new window with a key
+  combination (CTRL-N), then types in the Blink sketch, then auto-formats the
+  text using another key combination (CTRL-T), then uploads the sketch to the
+  currently selected Arduino using a final key combination (CTRL-U).
+
+  Circuit:
+  - Arduino Leonardo, Micro, Due, LilyPad USB, or Yún
+  - wire to connect D2 to ground
+
+  created 5 Mar 2012
+  modified 29 Mar 2012
+  by Tom Igoe
+  modified 3 May 2014
+  by Scott Fitzgerald
+
+  This example is in the public domain.
+
+  http://www.arduino.cc/en/Tutorial/KeyboardReprogram
+*/
+
+#include "Keyboard.h"
+
+// use this option for OSX.
+// Comment it out if using Windows or Linux:
+char ctrlKey = KEY_LEFT_GUI;
+// use this option for Windows and Linux.
+// leave commented out if using OSX:
+//  char ctrlKey = KEY_LEFT_CTRL;
+
+
+void setup() {
+  // make pin 2 an input and turn on the pull-up resistor so it goes high unless
+  // connected to ground:
+  pinMode(2, INPUT_PULLUP);
+  // initialize control over the keyboard:
+  Keyboard.begin();
+}
+
+void loop() {
+  while (digitalRead(2) == HIGH) {
+    // do nothing until pin 2 goes low
+    delay(500);
+  }
+  delay(1000);
+  // new document:
+  Keyboard.press(ctrlKey);
+  Keyboard.press('n');
+  delay(100);
+  Keyboard.releaseAll();
+  // wait for new window to open:
+  delay(1000);
+
+  // versions of the Arduino IDE after 1.5 pre-populate new sketches with
+  // setup() and loop() functions let's clear the window before typing anything new
+  // select all
+  Keyboard.press(ctrlKey);
+  Keyboard.press('a');
+  delay(500);
+  Keyboard.releaseAll();
+  // delete the selected text
+  Keyboard.write(KEY_BACKSPACE);
+  delay(500);
+
+  // Type out "blink":
+  Keyboard.println("void setup() {");
+  Keyboard.println("pinMode(13, OUTPUT);");
+  Keyboard.println("}");
+  Keyboard.println();
+  Keyboard.println("void loop() {");
+  Keyboard.println("digitalWrite(13, HIGH);");
+  Keyboard.print("delay(3000);");
+  // 3000 ms is too long. Delete it:
+  for (int keystrokes = 0; keystrokes < 6; keystrokes++) {
+    delay(500);
+    Keyboard.write(KEY_BACKSPACE);
+  }
+  // make it 1000 instead:
+  Keyboard.println("1000);");
+  Keyboard.println("digitalWrite(13, LOW);");
+  Keyboard.println("delay(1000);");
+  Keyboard.println("}");
+  // tidy up:
+  Keyboard.press(ctrlKey);
+  Keyboard.press('t');
+  delay(100);
+  Keyboard.releaseAll();
+  delay(3000);
+  // upload code:
+  Keyboard.press(ctrlKey);
+  Keyboard.press('u');
+  delay(100);
+  Keyboard.releaseAll();
+
+  // wait for the sweet oblivion of reprogramming:
+  while (true);
+}


### PR DESCRIPTION
Following https://github.com/arduino-libraries/Keyboard/pull/29, I went ahead and added the rest of the examples that I found on arduino.cc.
Once again, this is not my code, and I am simply making consistent in Github what I see on the official website.

Sources:
- [Message](https://www.arduino.cc/en/Tutorial/KeyboardMessage)
- [Logout](https://www.arduino.cc/en/Tutorial/KeyboardLogout)
- [Reprogram](https://www.arduino.cc/en/Tutorial/KeyboardReprogram)

I noticed that the website itself contains `[Get Code]` links which are often broken or don't link to the source-code.  I think it would be cool if we could change the links there to come to the examples here.  I found [this](https://github.com/arduino/reference-en/tree/master/Language/Functions/USB), but wasn't able to find the content for the specific example pages for which I could submit a PR.  Please let me know if you have any advice on this!