### PR TITLE
Add support for international layouts

### DIFF
--- a/src/Keyboard.cpp
+++ b/src/Keyboard.cpp
@@ -20,6 +20,7 @@
 */
 
 #include "Keyboard.h"
+#include "KeyboardLayout.h"
 
 #if defined(_USING_HID)
 
@@ -64,10 +65,12 @@ Keyboard_::Keyboard_(void)
 {
 	static HIDSubDescriptor node(_hidReportDescriptor, sizeof(_hidReportDescriptor));
 	HID().AppendDescriptor(&node);
+	_asciimap = 0;
 }
 
-void Keyboard_::begin(void)
+void Keyboard_::begin(const uint8_t *layout)
 {
+	_asciimap = layout;
 }
 
 void Keyboard_::end(void)
@@ -79,144 +82,6 @@ void Keyboard_::sendReport(KeyReport* keys)
 	HID().SendReport(2,keys,sizeof(KeyReport));
 }
 
-extern
-const uint8_t _asciimap[128] PROGMEM;
-
-#define SHIFT 0x80
-const uint8_t _asciimap[128] =
-{
-	0x00,             // NUL
-	0x00,             // SOH
-	0x00,             // STX
-	0x00,             // ETX
-	0x00,             // EOT
-	0x00,             // ENQ
-	0x00,             // ACK
-	0x00,             // BEL
-	0x2a,          // BS  Backspace
-	0x2b,          // TAB Tab
-	0x28,          // LF  Enter
-	0x00,             // VT
-	0x00,             // FF
-	0x00,             // CR
-	0x00,             // SO
-	0x00,             // SI
-	0x00,             // DEL
-	0x00,             // DC1
-	0x00,             // DC2
-	0x00,             // DC3
-	0x00,             // DC4
-	0x00,             // NAK
-	0x00,             // SYN
-	0x00,             // ETB
-	0x00,             // CAN
-	0x00,             // EM
-	0x00,             // SUB
-	0x00,             // ESC
-	0x00,             // FS
-	0x00,             // GS
-	0x00,             // RS
-	0x00,             // US
-
-	0x2c,          // ' '
-	0x1e|SHIFT,    // !
-	0x34|SHIFT,    // "
-	0x20|SHIFT,    // #
-	0x21|SHIFT,    // $
-	0x22|SHIFT,    // %
-	0x24|SHIFT,    // &
-	0x34,          // '
-	0x26|SHIFT,    // (
-	0x27|SHIFT,    // )
-	0x25|SHIFT,    // *
-	0x2e|SHIFT,    // +
-	0x36,          // ,
-	0x2d,          // -
-	0x37,          // .
-	0x38,          // /
-	0x27,          // 0
-	0x1e,          // 1
-	0x1f,          // 2
-	0x20,          // 3
-	0x21,          // 4
-	0x22,          // 5
-	0x23,          // 6
-	0x24,          // 7
-	0x25,          // 8
-	0x26,          // 9
-	0x33|SHIFT,    // :
-	0x33,          // ;
-	0x36|SHIFT,    // <
-	0x2e,          // =
-	0x37|SHIFT,    // >
-	0x38|SHIFT,    // ?
-	0x1f|SHIFT,    // @
-	0x04|SHIFT,    // A
-	0x05|SHIFT,    // B
-	0x06|SHIFT,    // C
-	0x07|SHIFT,    // D
-	0x08|SHIFT,    // E
-	0x09|SHIFT,    // F
-	0x0a|SHIFT,    // G
-	0x0b|SHIFT,    // H
-	0x0c|SHIFT,    // I
-	0x0d|SHIFT,    // J
-	0x0e|SHIFT,    // K
-	0x0f|SHIFT,    // L
-	0x10|SHIFT,    // M
-	0x11|SHIFT,    // N
-	0x12|SHIFT,    // O
-	0x13|SHIFT,    // P
-	0x14|SHIFT,    // Q
-	0x15|SHIFT,    // R
-	0x16|SHIFT,    // S
-	0x17|SHIFT,    // T
-	0x18|SHIFT,    // U
-	0x19|SHIFT,    // V
-	0x1a|SHIFT,    // W
-	0x1b|SHIFT,    // X
-	0x1c|SHIFT,    // Y
-	0x1d|SHIFT,    // Z
-	0x2f,          // [
-	0x31,          // bslash
-	0x30,          // ]
-	0x23|SHIFT,    // ^
-	0x2d|SHIFT,    // _
-	0x35,          // `
-	0x04,          // a
-	0x05,          // b
-	0x06,          // c
-	0x07,          // d
-	0x08,          // e
-	0x09,          // f
-	0x0a,          // g
-	0x0b,          // h
-	0x0c,          // i
-	0x0d,          // j
-	0x0e,          // k
-	0x0f,          // l
-	0x10,          // m
-	0x11,          // n
-	0x12,          // o
-	0x13,          // p
-	0x14,          // q
-	0x15,          // r
-	0x16,          // s
-	0x17,          // t
-	0x18,          // u
-	0x19,          // v
-	0x1a,          // w
-	0x1b,          // x
-	0x1c,          // y
-	0x1d,          // z
-	0x2f|SHIFT,    // {
-	0x31|SHIFT,    // |
-	0x30|SHIFT,    // }
-	0x35|SHIFT,    // ~
-	0x00              // DEL
-};
-
-
 uint8_t USBPutChar(uint8_t c);
 
 // press() adds the specified key (printing, non-printing, or modifier)
@@ -225,6 +90,10 @@ uint8_t USBPutChar(uint8_t c);
 // call release(), releaseAll(), or otherwise clear the report and resend.
 size_t Keyboard_::press(uint8_t k)
 {
+	// Do not be too harsh on users who forget to begin().
+	if (!_asciimap) {
+		begin();
+	}
 	uint8_t i;
 	if (k >= 136) {			// it's a non-printing key (not a modifier)
 		k = k - 136;
@@ -237,9 +106,15 @@ size_t Keyboard_::press(uint8_t k)
 			setWriteError();
 			return 0;
 		}
-		if (k & 0x80) {						// it's a capital letter or other character reached with shift
+		if ((k & ALT_GR) == ALT_GR) {
+			_keyReport.modifiers |= 0x40;   // AltGr = right Alt
+			k &= 0x3F;
+		} else if ((k & SHIFT) == SHIFT) {
 			_keyReport.modifiers |= 0x02;	// the left shift modifier
 			k &= 0x7F;
+		}
+		if (k == ISO_REPLACEMENT) {
+			k = ISO_KEY;
 		}
 	}
 
@@ -280,9 +155,15 @@ size_t Keyboard_::release(uint8_t k)
 		if (!k) {
 			return 0;
 		}
-		if (k & 0x80) {							// it's a capital letter or other character reached with shift
+		if ((k & ALT_GR) == ALT_GR) {
+			_keyReport.modifiers &= ~(0x40);   // AltGr = right Alt
+			k &= 0x3F;
+		} else if ((k & SHIFT) == SHIFT) {
 			_keyReport.modifiers &= ~(0x02);	// the left shift modifier
 			k &= 0x7F;
+		}
+		if (k == ISO_REPLACEMENT) {
+			k = ISO_KEY;
 		}
 	}
 

--- a/src/Keyboard.cpp
+++ b/src/Keyboard.cpp
@@ -65,7 +65,7 @@ Keyboard_::Keyboard_(void)
 {
 	static HIDSubDescriptor node(_hidReportDescriptor, sizeof(_hidReportDescriptor));
 	HID().AppendDescriptor(&node);
-	_asciimap = 0;
+	_asciimap = KeyboardLayout_en_US;
 }
 
 void Keyboard_::begin(const uint8_t *layout)
@@ -90,10 +90,6 @@ uint8_t USBPutChar(uint8_t c);
 // call release(), releaseAll(), or otherwise clear the report and resend.
 size_t Keyboard_::press(uint8_t k)
 {
-	// Do not be too harsh on users who forget to begin().
-	if (!_asciimap) {
-		begin();
-	}
 	uint8_t i;
 	if (k >= 136) {			// it's a non-printing key (not a modifier)
 		k = k - 136;

--- a/src/Keyboard.h
+++ b/src/Keyboard.h
@@ -83,6 +83,8 @@
 #define KEY_F23           0xFA
 #define KEY_F24           0xFB
 
+// Supported keyboard layouts
+extern const uint8_t KeyboardLayout_en_US[];
 
 // Low level key report: up to 6 keys and shift, ctrl etc at once
 typedef struct
@@ -96,10 +98,11 @@ class Keyboard_ : public Print
 {
 private:
   KeyReport _keyReport;
+  const uint8_t *_asciimap;
   void sendReport(KeyReport* keys);
 public:
   Keyboard_(void);
-  void begin(void);
+  void begin(const uint8_t *layout = KeyboardLayout_en_US);
   void end(void);
   size_t write(uint8_t k);
   size_t write(const uint8_t *buffer, size_t size);

--- a/src/Keyboard.h
+++ b/src/Keyboard.h
@@ -86,6 +86,7 @@
 // Supported keyboard layouts
 extern const uint8_t KeyboardLayout_de_DE[];
 extern const uint8_t KeyboardLayout_en_US[];
+extern const uint8_t KeyboardLayout_es_ES[];
 extern const uint8_t KeyboardLayout_fr_FR[];
 extern const uint8_t KeyboardLayout_it_IT[];
 

--- a/src/Keyboard.h
+++ b/src/Keyboard.h
@@ -85,6 +85,7 @@
 
 // Supported keyboard layouts
 extern const uint8_t KeyboardLayout_en_US[];
+extern const uint8_t KeyboardLayout_fr_FR[];
 
 // Low level key report: up to 6 keys and shift, ctrl etc at once
 typedef struct

--- a/src/Keyboard.h
+++ b/src/Keyboard.h
@@ -86,6 +86,7 @@
 // Supported keyboard layouts
 extern const uint8_t KeyboardLayout_en_US[];
 extern const uint8_t KeyboardLayout_fr_FR[];
+extern const uint8_t KeyboardLayout_it_IT[];
 
 // Low level key report: up to 6 keys and shift, ctrl etc at once
 typedef struct

--- a/src/Keyboard.h
+++ b/src/Keyboard.h
@@ -84,6 +84,7 @@
 #define KEY_F24           0xFB
 
 // Supported keyboard layouts
+extern const uint8_t KeyboardLayout_de_DE[];
 extern const uint8_t KeyboardLayout_en_US[];
 extern const uint8_t KeyboardLayout_fr_FR[];
 extern const uint8_t KeyboardLayout_it_IT[];

--- a/src/KeyboardLayout.h
+++ b/src/KeyboardLayout.h
@@ -1,0 +1,65 @@
+/*
+  KeyboardLayout.h
+
+  This file is not part of the public API. It is meant to be included
+  only in Keyboard.cpp and the keyboard layout files. Layout files map
+  ASCII character codes to keyboard scan codes (technically, to USB HID
+  Usage codes), possibly altered by the SHIFT or ALT_GR modifiers.
+
+  == Creating your own layout ==
+
+  In order to create your own layout file, copy an existing layout that
+  is similar to yours, then modify it to use the correct keys. The
+  layout is an array in ASCII order. Each entry contains a scan code,
+  possibly modified by "|SHIFT" or "|ALT_GR", as in this excerpt from
+  the Italian layout:
+
+      0x35,          // bslash
+      0x30|ALT_GR,   // ]
+      0x2e|SHIFT,    // ^
+
+  Do not change the control characters (those before scan code 0x2c,
+  corresponding to space). Do not attempt to grow the table past DEL. Do
+  not use both SHIFT and ALT_GR on the same character: this is not
+  supported. Unsupported characters should have 0x00 as scan code.
+
+  For a keyboard with an ISO physical layout, use the scan codes below:
+
+      +---+---+---+---+---+---+---+---+---+---+---+---+---+-------+
+      |35 |1e |1f |20 |21 |22 |23 |24 |25 |26 |27 |2d |2e |BackSp |
+      +---+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-----+
+      | Tab |14 |1a |08 |15 |17 |1c |18 |0c |12 |13 |2f |30 | Ret |
+      +-----++--++--++--++--++--++--++--++--++--++--++--++--++    |
+      |CapsL |04 |16 |07 |09 |0a |0b |0d |0e |0f |33 |34 |31 |    |
+      +----+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+---+----+
+      |Shi.|32 |1d |1b |06 |19 |05 |11 |10 |36 |37 |38 |  Shift   |
+      +----+---++--+-+-+---+---+---+---+---+--++---+---++----+----+
+      |Ctrl|Win |Alt |                        |AlGr|Win |Menu|Ctrl|
+      +----+----+----+------------------------+----+----+----+----+
+
+  The ANSI layout is identical except that key 0x31 is above (rather
+  than next to) Return, and there is not key 0x32.
+
+  Give a unique name to the layout array, then declare it in Keyboard.h
+  with a line of the form:
+
+    extern const uint8_t KeyboardLayout_xx_YY[];
+
+  == Encoding details ==
+
+  All scan codes are less than 0x80, which makes bit 7 available to
+  signal that a modifier (Shift or AltGr) is needed to generate the
+  character. With only one exception, keys that are used with modifiers
+  have scan codes that are less than 0x40. This makes bit 6 available
+  to signal whether the modifier is Shift or AltGr. The exception is
+  0x64, the key next next to Left Shift on the ISO layout (and absent
+  from the ANSI layout). We handle it by replacing its value by 0x32 in
+  the layout arrays.
+*/
+
+#include <Arduino.h>
+
+#define SHIFT 0x80
+#define ALT_GR 0xc0
+#define ISO_KEY 0x64
+#define ISO_REPLACEMENT 0x32

--- a/src/KeyboardLayout_de_DE.cpp
+++ b/src/KeyboardLayout_de_DE.cpp
@@ -1,0 +1,138 @@
+/*
+ * German keyboard layout.
+ */
+
+#include "KeyboardLayout.h"
+
+extern const uint8_t KeyboardLayout_de_DE[128] PROGMEM =
+{
+	0x00,          // NUL
+	0x00,          // SOH
+	0x00,          // STX
+	0x00,          // ETX
+	0x00,          // EOT
+	0x00,          // ENQ
+	0x00,          // ACK
+	0x00,          // BEL
+	0x2a,          // BS  Backspace
+	0x2b,          // TAB Tab
+	0x28,          // LF  Enter
+	0x00,          // VT
+	0x00,          // FF
+	0x00,          // CR
+	0x00,          // SO
+	0x00,          // SI
+	0x00,          // DEL
+	0x00,          // DC1
+	0x00,          // DC2
+	0x00,          // DC3
+	0x00,          // DC4
+	0x00,          // NAK
+	0x00,          // SYN
+	0x00,          // ETB
+	0x00,          // CAN
+	0x00,          // EM
+	0x00,          // SUB
+	0x00,          // ESC
+	0x00,          // FS
+	0x00,          // GS
+	0x00,          // RS
+	0x00,          // US
+
+	0x2c,          // ' '
+	0x1e|SHIFT,    // !
+	0x1f|SHIFT,    // "
+	0x31,          // #
+	0x21|SHIFT,    // $
+	0x22|SHIFT,    // %
+	0x23|SHIFT,    // &
+	0x31|SHIFT,    // '
+	0x25|SHIFT,    // (
+	0x26|SHIFT,    // )
+	0x30|SHIFT,    // *
+	0x30,          // +
+	0x36,          // ,
+	0x38,          // -
+	0x37,          // .
+	0x24|SHIFT,    // /
+	0x27,          // 0
+	0x1e,          // 1
+	0x1f,          // 2
+	0x20,          // 3
+	0x21,          // 4
+	0x22,          // 5
+	0x23,          // 6
+	0x24,          // 7
+	0x25,          // 8
+	0x26,          // 9
+	0x37|SHIFT,    // :
+	0x36|SHIFT,    // ;
+	0x32,          // <
+	0x27|SHIFT,    // =
+	0x32|SHIFT,    // >
+	0x2d|SHIFT,    // ?
+	0x14|ALT_GR,   // @
+	0x04|SHIFT,    // A
+	0x05|SHIFT,    // B
+	0x06|SHIFT,    // C
+	0x07|SHIFT,    // D
+	0x08|SHIFT,    // E
+	0x09|SHIFT,    // F
+	0x0a|SHIFT,    // G
+	0x0b|SHIFT,    // H
+	0x0c|SHIFT,    // I
+	0x0d|SHIFT,    // J
+	0x0e|SHIFT,    // K
+	0x0f|SHIFT,    // L
+	0x10|SHIFT,    // M
+	0x11|SHIFT,    // N
+	0x12|SHIFT,    // O
+	0x13|SHIFT,    // P
+	0x14|SHIFT,    // Q
+	0x15|SHIFT,    // R
+	0x16|SHIFT,    // S
+	0x17|SHIFT,    // T
+	0x18|SHIFT,    // U
+	0x19|SHIFT,    // V
+	0x1a|SHIFT,    // W
+	0x1b|SHIFT,    // X
+	0x1d|SHIFT,    // Y
+	0x1c|SHIFT,    // Z
+	0x25|ALT_GR,   // [
+	0x2d|ALT_GR,   // bslash
+	0x26|ALT_GR,   // ]
+	0x00,          // ^  not supported (requires dead key + space)
+	0x38|SHIFT,    // _
+	0x00,          // `  not supported (requires dead key + space)
+	0x04,          // a
+	0x05,          // b
+	0x06,          // c
+	0x07,          // d
+	0x08,          // e
+	0x09,          // f
+	0x0a,          // g
+	0x0b,          // h
+	0x0c,          // i
+	0x0d,          // j
+	0x0e,          // k
+	0x0f,          // l
+	0x10,          // m
+	0x11,          // n
+	0x12,          // o
+	0x13,          // p
+	0x14,          // q
+	0x15,          // r
+	0x16,          // s
+	0x17,          // t
+	0x18,          // u
+	0x19,          // v
+	0x1a,          // w
+	0x1b,          // x
+	0x1d,          // y
+	0x1c,          // z
+	0x24|ALT_GR,   // {
+	0x32|ALT_GR,   // |
+	0x27|ALT_GR,   // }
+	0x30|ALT_GR,   // ~
+	0x00           // DEL
+};

--- a/src/KeyboardLayout_en_US.cpp
+++ b/src/KeyboardLayout_en_US.cpp
@@ -1,0 +1,138 @@
+/*
+ * Standard US keyboard layout.
+ */
+
+#include "KeyboardLayout.h"
+
+extern const uint8_t KeyboardLayout_en_US[128] PROGMEM =
+{
+	0x00,          // NUL
+	0x00,          // SOH
+	0x00,          // STX
+	0x00,          // ETX
+	0x00,          // EOT
+	0x00,          // ENQ
+	0x00,          // ACK
+	0x00,          // BEL
+	0x2a,          // BS  Backspace
+	0x2b,          // TAB Tab
+	0x28,          // LF  Enter
+	0x00,          // VT
+	0x00,          // FF
+	0x00,          // CR
+	0x00,          // SO
+	0x00,          // SI
+	0x00,          // DEL
+	0x00,          // DC1
+	0x00,          // DC2
+	0x00,          // DC3
+	0x00,          // DC4
+	0x00,          // NAK
+	0x00,          // SYN
+	0x00,          // ETB
+	0x00,          // CAN
+	0x00,          // EM
+	0x00,          // SUB
+	0x00,          // ESC
+	0x00,          // FS
+	0x00,          // GS
+	0x00,          // RS
+	0x00,          // US
+
+	0x2c,          // ' '
+	0x1e|SHIFT,    // !
+	0x34|SHIFT,    // "
+	0x20|SHIFT,    // #
+	0x21|SHIFT,    // $
+	0x22|SHIFT,    // %
+	0x24|SHIFT,    // &
+	0x34,          // '
+	0x26|SHIFT,    // (
+	0x27|SHIFT,    // )
+	0x25|SHIFT,    // *
+	0x2e|SHIFT,    // +
+	0x36,          // ,
+	0x2d,          // -
+	0x37,          // .
+	0x38,          // /
+	0x27,          // 0
+	0x1e,          // 1
+	0x1f,          // 2
+	0x20,          // 3
+	0x21,          // 4
+	0x22,          // 5
+	0x23,          // 6
+	0x24,          // 7
+	0x25,          // 8
+	0x26,          // 9
+	0x33|SHIFT,    // :
+	0x33,          // ;
+	0x36|SHIFT,    // <
+	0x2e,          // =
+	0x37|SHIFT,    // >
+	0x38|SHIFT,    // ?
+	0x1f|SHIFT,    // @
+	0x04|SHIFT,    // A
+	0x05|SHIFT,    // B
+	0x06|SHIFT,    // C
+	0x07|SHIFT,    // D
+	0x08|SHIFT,    // E
+	0x09|SHIFT,    // F
+	0x0a|SHIFT,    // G
+	0x0b|SHIFT,    // H
+	0x0c|SHIFT,    // I
+	0x0d|SHIFT,    // J
+	0x0e|SHIFT,    // K
+	0x0f|SHIFT,    // L
+	0x10|SHIFT,    // M
+	0x11|SHIFT,    // N
+	0x12|SHIFT,    // O
+	0x13|SHIFT,    // P
+	0x14|SHIFT,    // Q
+	0x15|SHIFT,    // R
+	0x16|SHIFT,    // S
+	0x17|SHIFT,    // T
+	0x18|SHIFT,    // U
+	0x19|SHIFT,    // V
+	0x1a|SHIFT,    // W
+	0x1b|SHIFT,    // X
+	0x1c|SHIFT,    // Y
+	0x1d|SHIFT,    // Z
+	0x2f,          // [
+	0x31,          // bslash
+	0x30,          // ]
+	0x23|SHIFT,    // ^
+	0x2d|SHIFT,    // _
+	0x35,          // `
+	0x04,          // a
+	0x05,          // b
+	0x06,          // c
+	0x07,          // d
+	0x08,          // e
+	0x09,          // f
+	0x0a,          // g
+	0x0b,          // h
+	0x0c,          // i
+	0x0d,          // j
+	0x0e,          // k
+	0x0f,          // l
+	0x10,          // m
+	0x11,          // n
+	0x12,          // o
+	0x13,          // p
+	0x14,          // q
+	0x15,          // r
+	0x16,          // s
+	0x17,          // t
+	0x18,          // u
+	0x19,          // v
+	0x1a,          // w
+	0x1b,          // x
+	0x1c,          // y
+	0x1d,          // z
+	0x2f|SHIFT,    // {
+	0x31|SHIFT,    // |
+	0x30|SHIFT,    // }
+	0x35|SHIFT,    // ~
+	0x00           // DEL
+};

--- a/src/KeyboardLayout_es_ES.cpp
+++ b/src/KeyboardLayout_es_ES.cpp
@@ -1,0 +1,138 @@
+/*
+ * Spanish keyboard layout.
+ */
+
+#include "KeyboardLayout.h"
+
+extern const uint8_t KeyboardLayout_es_ES[128] PROGMEM =
+{
+	0x00,          // NUL
+	0x00,          // SOH
+	0x00,          // STX
+	0x00,          // ETX
+	0x00,          // EOT
+	0x00,          // ENQ
+	0x00,          // ACK
+	0x00,          // BEL
+	0x2a,          // BS  Backspace
+	0x2b,          // TAB Tab
+	0x28,          // LF  Enter
+	0x00,          // VT
+	0x00,          // FF
+	0x00,          // CR
+	0x00,          // SO
+	0x00,          // SI
+	0x00,          // DEL
+	0x00,          // DC1
+	0x00,          // DC2
+	0x00,          // DC3
+	0x00,          // DC4
+	0x00,          // NAK
+	0x00,          // SYN
+	0x00,          // ETB
+	0x00,          // CAN
+	0x00,          // EM
+	0x00,          // SUB
+	0x00,          // ESC
+	0x00,          // FS
+	0x00,          // GS
+	0x00,          // RS
+	0x00,          // US
+
+	0x2c,          // ' '
+	0x1e|SHIFT,    // !
+	0x1f|SHIFT,    // "
+	0x20|ALT_GR,   // #
+	0x21|SHIFT,    // $
+	0x22|SHIFT,    // %
+	0x23|SHIFT,    // &
+	0x2d,          // '
+	0x25|SHIFT,    // (
+	0x26|SHIFT,    // )
+	0x30|SHIFT,    // *
+	0x30,          // +
+	0x36,          // ,
+	0x38,          // -
+	0x37,          // .
+	0x24|SHIFT,    // /
+	0x27,          // 0
+	0x1e,          // 1
+	0x1f,          // 2
+	0x20,          // 3
+	0x21,          // 4
+	0x22,          // 5
+	0x23,          // 6
+	0x24,          // 7
+	0x25,          // 8
+	0x26,          // 9
+	0x37|SHIFT,    // :
+	0x36|SHIFT,    // ;
+	0x32,          // <
+	0x27|SHIFT,    // =
+	0x32|SHIFT,    // >
+	0x2d|SHIFT,    // ?
+	0x1f|ALT_GR,   // @
+	0x04|SHIFT,    // A
+	0x05|SHIFT,    // B
+	0x06|SHIFT,    // C
+	0x07|SHIFT,    // D
+	0x08|SHIFT,    // E
+	0x09|SHIFT,    // F
+	0x0a|SHIFT,    // G
+	0x0b|SHIFT,    // H
+	0x0c|SHIFT,    // I
+	0x0d|SHIFT,    // J
+	0x0e|SHIFT,    // K
+	0x0f|SHIFT,    // L
+	0x10|SHIFT,    // M
+	0x11|SHIFT,    // N
+	0x12|SHIFT,    // O
+	0x13|SHIFT,    // P
+	0x14|SHIFT,    // Q
+	0x15|SHIFT,    // R
+	0x16|SHIFT,    // S
+	0x17|SHIFT,    // T
+	0x18|SHIFT,    // U
+	0x19|SHIFT,    // V
+	0x1a|SHIFT,    // W
+	0x1b|SHIFT,    // X
+	0x1c|SHIFT,    // Y
+	0x1d|SHIFT,    // Z
+	0x2f|ALT_GR,   // [
+	0x35|ALT_GR,   // bslash
+	0x30|ALT_GR,   // ]
+	0x00,          // ^  not supported (requires dead key + space)
+	0x38|SHIFT,    // _
+	0x00,          // `  not supported (requires dead key + space)
+	0x04,          // a
+	0x05,          // b
+	0x06,          // c
+	0x07,          // d
+	0x08,          // e
+	0x09,          // f
+	0x0a,          // g
+	0x0b,          // h
+	0x0c,          // i
+	0x0d,          // j
+	0x0e,          // k
+	0x0f,          // l
+	0x10,          // m
+	0x11,          // n
+	0x12,          // o
+	0x13,          // p
+	0x14,          // q
+	0x15,          // r
+	0x16,          // s
+	0x17,          // t
+	0x18,          // u
+	0x19,          // v
+	0x1a,          // w
+	0x1b,          // x
+	0x1c,          // y
+	0x1d,          // z
+	0x34|ALT_GR,   // {
+	0x1e|ALT_GR,   // |
+	0x31|ALT_GR,   // }
+	0x00,          // ~  not supported (requires dead key + space)
+	0x00           // DEL
+};

--- a/src/KeyboardLayout_fr_FR.cpp
+++ b/src/KeyboardLayout_fr_FR.cpp
@@ -1,0 +1,138 @@
+/*
+ * Traditional (not AFNOR) French keyboard layout.
+ */
+
+#include "KeyboardLayout.h"
+
+extern const uint8_t KeyboardLayout_fr_FR[128] PROGMEM =
+{
+	0x00,          // NUL
+	0x00,          // SOH
+	0x00,          // STX
+	0x00,          // ETX
+	0x00,          // EOT
+	0x00,          // ENQ
+	0x00,          // ACK
+	0x00,          // BEL
+	0x2a,          // BS  Backspace
+	0x2b,          // TAB Tab
+	0x28,          // LF  Enter
+	0x00,          // VT
+	0x00,          // FF
+	0x00,          // CR
+	0x00,          // SO
+	0x00,          // SI
+	0x00,          // DEL
+	0x00,          // DC1
+	0x00,          // DC2
+	0x00,          // DC3
+	0x00,          // DC4
+	0x00,          // NAK
+	0x00,          // SYN
+	0x00,          // ETB
+	0x00,          // CAN
+	0x00,          // EM
+	0x00,          // SUB
+	0x00,          // ESC
+	0x00,          // FS
+	0x00,          // GS
+	0x00,          // RS
+	0x00,          // US
+
+	0x2c,          // ' '
+	0x38,          // !
+	0x20,          // "
+	0x20|ALT_GR,   // #
+	0x30,          // $
+	0x34|SHIFT,    // %
+	0x1E,          // &
+	0x21,          // '
+	0x22,          // (
+	0x2d,          // )
+	0x31,          // *
+	0x2e|SHIFT,    // +
+	0x10,          // ,
+	0x23,          // -
+	0x36|SHIFT,    // .
+	0x37|SHIFT,    // /
+	0x27|SHIFT,    // 0
+	0x1e|SHIFT,    // 1
+	0x1f|SHIFT,    // 2
+	0x20|SHIFT,    // 3
+	0x21|SHIFT,    // 4
+	0x22|SHIFT,    // 5
+	0x23|SHIFT,    // 6
+	0x24|SHIFT,    // 7
+	0x25|SHIFT,    // 8
+	0x26|SHIFT,    // 9
+	0x37,          // :
+	0x36,          // ;
+	0x32,          // <
+	0x2e,          // =
+	0x32|SHIFT,    // >
+	0x10|SHIFT,    // ?
+	0x27|ALT_GR,   // @
+	0x14|SHIFT,    // A
+	0x05|SHIFT,    // B
+	0x06|SHIFT,    // C
+	0x07|SHIFT,    // D
+	0x08|SHIFT,    // E
+	0x09|SHIFT,    // F
+	0x0a|SHIFT,    // G
+	0x0b|SHIFT,    // H
+	0x0c|SHIFT,    // I
+	0x0d|SHIFT,    // J
+	0x0e|SHIFT,    // K
+	0x0f|SHIFT,    // L
+	0x33|SHIFT,    // M
+	0x11|SHIFT,    // N
+	0x12|SHIFT,    // O
+	0x13|SHIFT,    // P
+	0x04|SHIFT,    // Q
+	0x15|SHIFT,    // R
+	0x16|SHIFT,    // S
+	0x17|SHIFT,    // T
+	0x18|SHIFT,    // U
+	0x19|SHIFT,    // V
+	0x1d|SHIFT,    // W
+	0x1b|SHIFT,    // X
+	0x1c|SHIFT,    // Y
+	0x1a|SHIFT,    // Z
+	0x22|ALT_GR,   // [
+	0x25|ALT_GR,   // bslash
+	0x2d|ALT_GR,   // ]
+	0x26|ALT_GR,   // ^
+	0x25,          // _
+	0x24|ALT_GR,   // `
+	0x14,          // a
+	0x05,          // b
+	0x06,          // c
+	0x07,          // d
+	0x08,          // e
+	0x09,          // f
+	0x0a,          // g
+	0x0b,          // h
+	0x0c,          // i
+	0x0d,          // j
+	0x0e,          // k
+	0x0f,          // l
+	0x33,          // m
+	0x11,          // n
+	0x12,          // o
+	0x13,          // p
+	0x04,          // q
+	0x15,          // r
+	0x16,          // s
+	0x17,          // t
+	0x18,          // u
+	0x19,          // v
+	0x1d,          // w
+	0x1b,          // x
+	0x1c,          // y
+	0x1a,          // z
+	0x21|ALT_GR,   // {
+	0x23|ALT_GR,   // |
+	0x2e|ALT_GR,   // }
+	0x1f|ALT_GR,   // ~
+	0x00           // DEL
+};

--- a/src/KeyboardLayout_it_IT.cpp
+++ b/src/KeyboardLayout_it_IT.cpp
@@ -1,0 +1,138 @@
+/*
+ * Italian keyboard layout.
+ */
+
+#include "KeyboardLayout.h"
+
+extern const uint8_t KeyboardLayout_it_IT[128] PROGMEM =
+{
+	0x00,          // NUL
+	0x00,          // SOH
+	0x00,          // STX
+	0x00,          // ETX
+	0x00,          // EOT
+	0x00,          // ENQ
+	0x00,          // ACK
+	0x00,          // BEL
+	0x2a,          // BS  Backspace
+	0x2b,          // TAB Tab
+	0x28,          // LF  Enter
+	0x00,          // VT
+	0x00,          // FF
+	0x00,          // CR
+	0x00,          // SO
+	0x00,          // SI
+	0x00,          // DEL
+	0x00,          // DC1
+	0x00,          // DC2
+	0x00,          // DC3
+	0x00,          // DC4
+	0x00,          // NAK
+	0x00,          // SYN
+	0x00,          // ETB
+	0x00,          // CAN
+	0x00,          // EM
+	0x00,          // SUB
+	0x00,          // ESC
+	0x00,          // FS
+	0x00,          // GS
+	0x00,          // RS
+	0x00,          // US
+
+	0x2c,          // ' '
+	0x1e|SHIFT,    // !
+	0x1f|SHIFT,    // "
+	0x34|ALT_GR,   // #
+	0x21|SHIFT,    // $
+	0x22|SHIFT,    // %
+	0x23|SHIFT,    // &
+	0x2d,          // '
+	0x25|SHIFT,    // (
+	0x26|SHIFT,    // )
+	0x30|SHIFT,    // *
+	0x30,          // +
+	0x36,          // ,
+	0x38,          // -
+	0x37,          // .
+	0x24|SHIFT,    // /
+	0x27,          // 0
+	0x1e,          // 1
+	0x1f,          // 2
+	0x20,          // 3
+	0x21,          // 4
+	0x22,          // 5
+	0x23,          // 6
+	0x24,          // 7
+	0x25,          // 8
+	0x26,          // 9
+	0x37|SHIFT,    // :
+	0x36|SHIFT,    // ;
+	0x32,          // <
+	0x27|SHIFT,    // =
+	0x32|SHIFT,    // >
+	0x2d|SHIFT,    // ?
+	0x33|ALT_GR,   // @
+	0x04|SHIFT,    // A
+	0x05|SHIFT,    // B
+	0x06|SHIFT,    // C
+	0x07|SHIFT,    // D
+	0x08|SHIFT,    // E
+	0x09|SHIFT,    // F
+	0x0a|SHIFT,    // G
+	0x0b|SHIFT,    // H
+	0x0c|SHIFT,    // I
+	0x0d|SHIFT,    // J
+	0x0e|SHIFT,    // K
+	0x0f|SHIFT,    // L
+	0x10|SHIFT,    // M
+	0x11|SHIFT,    // N
+	0x12|SHIFT,    // O
+	0x13|SHIFT,    // P
+	0x14|SHIFT,    // Q
+	0x15|SHIFT,    // R
+	0x16|SHIFT,    // S
+	0x17|SHIFT,    // T
+	0x18|SHIFT,    // U
+	0x19|SHIFT,    // V
+	0x1a|SHIFT,    // W
+	0x1b|SHIFT,    // X
+	0x1c|SHIFT,    // Y
+	0x1d|SHIFT,    // Z
+	0x2f|ALT_GR,   // [
+	0x35,          // bslash
+	0x30|ALT_GR,   // ]
+	0x2e|SHIFT,    // ^
+	0x38|SHIFT,    // _
+	0x00,          // `  not in this layout
+	0x04,          // a
+	0x05,          // b
+	0x06,          // c
+	0x07,          // d
+	0x08,          // e
+	0x09,          // f
+	0x0a,          // g
+	0x0b,          // h
+	0x0c,          // i
+	0x0d,          // j
+	0x0e,          // k
+	0x0f,          // l
+	0x10,          // m
+	0x11,          // n
+	0x12,          // o
+	0x13,          // p
+	0x14,          // q
+	0x15,          // r
+	0x16,          // s
+	0x17,          // t
+	0x18,          // u
+	0x19,          // v
+	0x1a,          // w
+	0x1b,          // x
+	0x1c,          // y
+	0x1d,          // z
+	0x00,          // {  not supported (requires AltGr+Shift)
+	0x35|SHIFT,    // |
+	0x00,          // }  not supported (requires AltGr+Shift)
+	0x00,          // ~  not in this layout
+	0x00           // DEL
+};


### PR DESCRIPTION
This pull request adds support for multiple keyboard layouts. Five layouts are initially included: US, French, Italian, German and Spanish. It is expected that users contribute additional layouts (I can add a few if requested). Adding a layout is straightforward by following the instructions in KeyboardLayout.h. It only requires one file defining it, and one line added to Keyboard.h.

## Context

Arduino was born in Italy and has become very popular [all over the world][trends]. The USA is only one among many countries that show interest in Arduino, and yet, the official Arduino Keyboard library supports exclusively the US keyboard layout. This has caused much confusion (#7, #20, #23, #24) and user requests (#8, #21, #25, #50, #52).

In the past, requests to support international layouts have been rejected with two arguments:

1. this library should stay simple and small
2. [NicoHood's HID library][hid] is available for those needing advanced features.

Regarding point 2, it should be noted that:

* For the majority of Arduino users (mostly everybody outside the USA), support for a keyboard layout other than US is by no means an “advanced feature”: it is the most basic way of using any keyboard-like device.
* The HID library is very limited in its support of keyboard layouts, as [the API does not support the <kbd>AltGr</kbd> modifier][hid-wiki].

This pull request addresses this need while keeping the code simple and small.

## API change

The only change to the public API is that the `begin()` method now accepts an optional parameter specifying the requested keyboard layout, e.g.

```c++
Keyboard.begin(KeyboardLayout_fr_FR);
```

As an optional parameter, it defaults to `KeyboardLayout_en_US`, thus preserving compatibility with existing sketches.

Even though calling `begin()` is mandatory according to the official documentation, this method has been a noop until now. In order to avoid breaking existing sketches that fail to `begin()`, the `press()` method now calls `begin()` if it hasn't been called before.

## Resource usage

For a sketch using the default layout, the cost of this change is 100&nbsp;bytes of flash and 2&nbsp;bytes of RAM, as measured on an Arduino Micro. This doesn't change as the number of supported layouts increases.

Using a layout other than the default costs an extra 128&nbsp;bytes of flash. This is because the default layout is always loaded in order to handle the case where the user forgets to `begin()` before using the library. It could be discussed whether supporting sketches that fail to `begin()` is worth the cost.

## Limitations

Keeping this library simple and small is a must. Because of this, this feature comes with some limitations:

1. Only ASCII characters are supported. Supporting non-ASCII characters would require parsing UTF-8 input, which would add significant complexity (see, e.g. #52).
2. While both the <kbd>Shift</kbd> and <kbd>AltGr</kbd> modifiers are supported, using both _simultaneously_ for typing a single character is not supported. Supporting this would not add complexity, but it would require growing the ASCII map to 16&nbsp;bits per cell (as in #50), which would cost 128&nbsp;extra bytes of flash.
3. Characters requiring hitting multiple keys _consecutively_ (like dead circumflex + space → `^` on some layouts) are not supported for the same reason. They also break the simple assumption that `write(character)` equals `press(character)` followed by `release(character)`.

[trends]: https://trends.google.com/trends/explore?q=Arduino#GEO_MAP
[hid]: https://github.com/NicoHood/HID
[hid-wiki]: https://github.com/NicoHood/HID/wiki/Keyboard-API#keyboard-layouts