### PR TITLE
CI: do not compile examples for Mbed boards

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -40,18 +40,6 @@ jobs:
           - fqbn: arduino:samd:mkrzero
             platforms: |
               - name: arduino:samd
-          - fqbn: arduino:mbed_portenta:envie_m4
-            platforms: |
-              - name: arduino:mbed_portenta
-          - fqbn: arduino:mbed_portenta:envie_m7
-            platforms: |
-              - name: arduino:mbed_portenta
-          - fqbn: arduino:mbed_nano:nano33ble
-            platforms: |
-              - name: arduino:mbed_nano
-          - fqbn: arduino:mbed_nano:nanorp2040connect
-            platforms: |
-              - name: arduino:mbed_nano
 
     steps:
       - name: Checkout repository

--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=Allows an Arduino board with USB capabilities to act as a Keyboard.
 paragraph=This library plugs on the HID library. It can be used with or without other HID-based libraries (Mouse, Gamepad etc)
 category=Device Control
 url=https://www.arduino.cc/reference/en/language/functions/usb/keyboard/
-architectures=*
+architectures=avr, samd, sam


### PR DESCRIPTION
Since the merge of pull request #46, the “Compile Examples” GitHub Actions workflow has systematically failed:

 - the jobs arduino:avr:leonardo, arduino:sam:arduino\_due\_x\_dbg and arduino:samd:mkrzero succeed
 - the jobs arduino:mbed\_portenta:\* and arduino:mbed\_nano:\* fail

All the failures are caused by [this error][]:

```text
In file included from /[...]/examples/Serial/Serial.ino:22:0:
/[...]/src/Keyboard.h:25:10: fatal error: HID.h: No such file or directory
 #include "HID.h"
          ^~~~~~~
```

The underlying reason is that this library relies on the HID library, which does not support the mbed\_nano and mbed\_portenta platforms.

This pull request removes those boards from the list of boards this library is to be tested for.

[this error]: /arduino-libraries/Keyboard/runs/4102458229?check_suite_focus=true