### PR TITLE
Add definitions for missing keys

### DIFF
--- a/src/Keyboard.h
+++ b/src/Keyboard.h
@@ -34,6 +34,7 @@
 //================================================================================
 //  Keyboard
 
+// Modifiers
 #define KEY_LEFT_CTRL     0x80
 #define KEY_LEFT_SHIFT    0x81
 #define KEY_LEFT_ALT      0x82
@@ -43,6 +44,7 @@
 #define KEY_RIGHT_ALT     0x86
 #define KEY_RIGHT_GUI     0x87
 
+// Misc keys
 #define KEY_UP_ARROW      0xDA
 #define KEY_DOWN_ARROW    0xD9
 #define KEY_LEFT_ARROW    0xD8
@@ -50,6 +52,7 @@
 #define KEY_BACKSPACE     0xB2
 #define KEY_TAB           0xB3
 #define KEY_RETURN        0xB0
+#define KEY_MENU          0xED // "Keyboard Application" in USB standard
 #define KEY_ESC           0xB1
 #define KEY_INSERT        0xD1
 #define KEY_DELETE        0xD4
@@ -58,6 +61,30 @@
 #define KEY_HOME          0xD2
 #define KEY_END           0xD5
 #define KEY_CAPS_LOCK     0xC1
+#define KEY_PRINT_SCREEN  0xCE // Print Screen / SysRq
+#define KEY_SCROLL_LOCK   0xCF
+#define KEY_PAUSE         0xD0 // Pause / Break
+
+// Numeric keypad
+#define KEY_NUM_LOCK      0xDB
+#define KEY_KP_SLASH      0xDC
+#define KEY_KP_ASTERISK   0xDD
+#define KEY_KP_MINUS      0xDE
+#define KEY_KP_PLUS       0xDF
+#define KEY_KP_ENTER      0xE0
+#define KEY_KP_1          0xE1
+#define KEY_KP_2          0xE2
+#define KEY_KP_3          0xE3
+#define KEY_KP_4          0xE4
+#define KEY_KP_5          0xE5
+#define KEY_KP_6          0xE6
+#define KEY_KP_7          0xE7
+#define KEY_KP_8          0xE8
+#define KEY_KP_9          0xE9
+#define KEY_KP_0          0xEA
+#define KEY_KP_DOT        0xEB
+
+// Function keys
 #define KEY_F1            0xC2
 #define KEY_F2            0xC3
 #define KEY_F3            0xC4


### PR DESCRIPTION
The header file Keyboard.h provides definitions for many keys that do not map to printable characters, such as `KEY_BACKSPACE`, `KEY_RIGHT_ARROW`, `KEY_F1`, etc. Some keys are missing, though, to fully cover a standard full-size PC keyboard:

* the <kbd>Menu</kbd> key
* the cluster at the top right: <kbd>Print Screen / SysRq</kbd>, <kbd>Scroll Lock</kbd> and <kbd>Pause / Break</kbd>
* the 17 keys of the numeric keypad

This pull request adds macro definitions for these missing keys, thus completing the emulation of a full-size keyboard.