### PR TITLE
Add definitions for extra keys in national layouts

### DIFF
--- a/src/Keyboard_de_DE.h
+++ b/src/Keyboard_de_DE.h
@@ -1,0 +1,45 @@
+/*
+  Keyboard_de_DE.h
+
+  Copyright (c) 2022, Edgar Bonet
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#ifndef KEYBOARD_DE_DE_h
+#define KEYBOARD_DE_DE_h
+
+#include "HID.h"
+
+#if !defined(_USING_HID)
+
+#warning "Using legacy HID core (non pluggable)"
+
+#else
+
+//================================================================================
+//================================================================================
+//  Keyboard
+
+// de_DE keys
+#define KEY_CIRCUMFLEX    (136+0x35)
+#define KEY_ESZETT        (136+0x2d)
+#define KEY_ACUTE         (136+0x2e)
+#define KEY_U_UMLAUT      (136+0x2f)
+#define KEY_O_UMLAUT      (136+0x33)
+#define KEY_A_UMLAUT      (136+0x34)
+
+#endif
+#endif

--- a/src/Keyboard_es_ES.h
+++ b/src/Keyboard_es_ES.h
@@ -1,0 +1,45 @@
+/*
+  Keyboard_es_ES.h
+
+  Copyright (c) 2022, Edgar Bonet
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#ifndef KEYBOARD_ES_ES_h
+#define KEYBOARD_ES_ES_h
+
+#include "HID.h"
+
+#if !defined(_USING_HID)
+
+#warning "Using legacy HID core (non pluggable)"
+
+#else
+
+//================================================================================
+//================================================================================
+//  Keyboard
+
+// es_ES keys
+#define KEY_MASCULINE_ORDINAL    (136+0x35)
+#define KEY_INVERTED_EXCLAMATION (136+0x2e)
+#define KEY_GRAVE                (136+0x2f)
+#define KEY_N_TILDE              (136+0x33)
+#define KEY_ACUTE                (136+0x34)
+#define KEY_C_CEDILLA            (136+0x31)
+
+#endif
+#endif

--- a/src/Keyboard_fr_FR.h
+++ b/src/Keyboard_fr_FR.h
@@ -1,0 +1,46 @@
+/*
+  Keyboard_fr_FR.h
+
+  Copyright (c) 2022, Edgar Bonet
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#ifndef KEYBOARD_FR_FR_h
+#define KEYBOARD_FR_FR_h
+
+#include "HID.h"
+
+#if !defined(_USING_HID)
+
+#warning "Using legacy HID core (non pluggable)"
+
+#else
+
+//================================================================================
+//================================================================================
+//  Keyboard
+
+// fr_FR keys
+#define KEY_SUPERSCRIPT_TWO (136+0x35)
+#define KEY_E_ACUTE         (136+0x1f)
+#define KEY_E_GRAVE         (136+0x24)
+#define KEY_C_CEDILLA       (136+0x26)
+#define KEY_A_GRAVE         (136+0x27)
+#define KEY_CIRCUMFLEX      (136+0x2f)
+#define KEY_U_GRAVE         (136+0x34)
+
+#endif
+#endif

--- a/src/Keyboard_it_IT.h
+++ b/src/Keyboard_it_IT.h
@@ -1,0 +1,44 @@
+/*
+  Keyboard_it_IT.h
+
+  Copyright (c) 2022, Edgar Bonet
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#ifndef KEYBOARD_IT_IT_h
+#define KEYBOARD_IT_IT_h
+
+#include "HID.h"
+
+#if !defined(_USING_HID)
+
+#warning "Using legacy HID core (non pluggable)"
+
+#else
+
+//================================================================================
+//================================================================================
+//  Keyboard
+
+// it_IT keys
+#define KEY_I_GRAVE       (136+0x2e)
+#define KEY_E_GRAVE       (136+0x2f)
+#define KEY_O_GRAVE       (136+0x33)
+#define KEY_A_GRAVE       (136+0x34)
+#define KEY_U_GRAVE       (136+0x31)
+
+#endif
+#endif


### PR DESCRIPTION
Pull requests #58 and #60 added support for the Swedish and Danish keyboard layouts. Unlike the previously supported layouts, these new layouts came each with a header file that provides macro definitions for the keys that are not otherwise easily accessible. For example, Keyboard\_sv\_SE.h defines:

```c
#define KEY_A_RING        (136+0x2f)
#define KEY_A_UMLAUT      (136+0x34)
#define KEY_O_UMLAUT      (136+0x33)
#define KEY_UMLAUT        (136+0x30)
#define KEY_ACUTE_ACC     (136+0x2e)
```

This pull request extends this to all the other supported layouts, namely de\_DE, es\_ES, fr\_FR and it\_IT. Note that en\_US does not require such support, as all its keys are already readily accessible.

With this new definitions, every single key of a full-size PC keyboard can now be reached on every layout, either with `Keyboard.write(ASCII_char)` or by using one of the provided macros.

**Example**: the following sketch prints “ça va être drôle!” on a French keyboard:

```c++
#include <Keyboard.h>
#include <Keyboard_fr_FR.h>

void setup() {
    Keyboard.begin(KeyboardLayout_fr_FR);
    delay(5000);
    Keyboard.write(KEY_C_CEDILLA);
    Keyboard.print("a va ");
    Keyboard.write(KEY_CIRCUMFLEX);
    Keyboard.print("etre dr");
    Keyboard.write(KEY_CIRCUMFLEX);
    Keyboard.println("ole!");
}

void loop(){}
```