### PR TITLE
Fix French circumflex & umlaut accents

### DIFF
--- a/src/KeyboardLayout_fr_FR.cpp
+++ b/src/KeyboardLayout_fr_FR.cpp
@@ -45,7 +45,7 @@ extern const uint8_t KeyboardLayout_fr_FR[128] PROGMEM =
 	0x20|ALT_GR,   // #
 	0x30,          // $
 	0x34|SHIFT,    // %
-	0x1E,          // &
+	0x1e,          // &
 	0x21,          // '
 	0x22,          // (
 	0x2d,          // )
@@ -101,7 +101,7 @@ extern const uint8_t KeyboardLayout_fr_FR[128] PROGMEM =
 	0x22|ALT_GR,   // [
 	0x25|ALT_GR,   // bslash
 	0x2d|ALT_GR,   // ]
-	0x26|ALT_GR,   // ^
+	0x2f,          // ^
 	0x25,          // _
 	0x24|ALT_GR,   // `
 	0x14,          // a


### PR DESCRIPTION
Hi, 
This PR replaces the circumflex accent obtained by modifier with the key directly available on French keyboards. 
This brings the 0x2f scan code available and allows to be able to generate letters with umlaut using the modifier shift + '^'.

```
Keyboard.write(KEY_CIRCUMFLEX);
Keyboard.write('i');

Keyboard.press(KEY_LEFT_SHIFT);
Keyboard.press('^');
Keyboard.releaseAll();
Keyboard.write('i');
```

Gives:
`îï`

The KEY_CIRCUMFLEX macro is now redundant but I guess that's syntactic sugar.