### PR TITLE
Add clarifying comment in KeyboardLayout.h

### DIFF
--- a/src/KeyboardLayout.h
+++ b/src/KeyboardLayout.h
@@ -5,6 +5,8 @@
   only in Keyboard.cpp and the keyboard layout files. Layout files map
   ASCII character codes to keyboard scan codes (technically, to USB HID
   Usage codes), possibly altered by the SHIFT or ALT_GR modifiers.
+  Non-ACSII characters (anything outside the 7-bit range NUL..DEL) are
+  not supported.
 
   == Creating your own layout ==
 


### PR DESCRIPTION
Users are encouraged to write their own national keyboard layouts, and the comments in KeyboardLayout.h provide the documentation for doing so. It has been suggested to me that it would be good to make crystal clear in this documentation that characters outside the 7-bit ASCII range are not supported.

This pull requests adds this clarification.