### PR TITLE
Add renesas_uno to list of supported architectures

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=Allows an Arduino board with USB capabilities to act as a Keyboard.
 paragraph=This library plugs on the HID library. It can be used with or without other HID-based libraries (Mouse, Gamepad etc)
 category=Device Control
 url=https://www.arduino.cc/reference/en/language/functions/usb/keyboard/
-architectures=avr, samd, sam
+architectures=avr, samd, sam, renesas_uno


### PR DESCRIPTION
The UNO R4 WiFi & Minima boards are supported but the `renesas_uno` architecture is missing in `library.properties`. This PR adds it to list of supported architectures.