### PR TITLE
README: update documentation link

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -10,7 +10,7 @@ image:https://github.com/{repository-owner}/{repository-name}/actions/workflows/
 This library allows an Arduino board with USB capabilities to act as a keyboard.
 
 For more information about this library please visit us at
-https://www.arduino.cc/reference/en/language/functions/usb/keyboard/
+https://docs.arduino.cc/language-reference/en/functions/usb/Keyboard/
 
 == License ==
 


### PR DESCRIPTION
At some point the page moved from www.arduino.cc to docs.arduino.cc with a 301 to redirect existing documentation. The redirect is, unfortunately, case sensitive so the URL as given is inaccessible.

Update to point directly to docs.arduino.cc and fix the case.

--- 

This is probably one of the most useless PRs I've submitted but it was bothering me.